### PR TITLE
Fixed USERNAME env var typo

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,7 +1,7 @@
 # MAKE SURE TO CHANGE THE VALUES BELOW TO YOUR OWN
 # REMEMBER TO REMOVE THE "example" text FROM THE FILE NAME
 # USE A SECOND STEAM ACCOUNT TO RUN SERVER AND THE ACCOUNT NEEDS TO OWN THE GAME
-USERNAMER=<username>
+USERNAME=<username>
 PASSWORD=<password>
 APPID=671860
 SERVER=<server> #change it where you want the battlebit server files installed to (ex. /home/username/battlebit)

--- a/main/scripts.py
+++ b/main/scripts.py
@@ -8,7 +8,7 @@ def create_file():
     """Creates a file update.txt in the SteamCMD folder with the commands to be executed."""
     # Environment variables
     server = os.getenv("SERVER")
-    username = os.getenv("USERNAMER")
+    username = os.getenv("USERNAME")
     password = os.getenv("PASSWORD")
     appid = os.getenv("APPID")
 


### PR DESCRIPTION
- Replaced USERNAMER var with USERNAME, misspelling is confusing when making the env file, unless you copy the example line-by-line.